### PR TITLE
Endpoint de detail no envía más arrays

### DIFF
--- a/src/Post/services/Post.service.js
+++ b/src/Post/services/Post.service.js
@@ -81,6 +81,7 @@ module.exports = {
 
     },
     detailPost: async(req, res)=>{
+        const { postId } = req.params
         try{
             // //extraemos el id del post por params
             // const {postId} = req.params
@@ -91,74 +92,111 @@ module.exports = {
             // if (searchedPost == null) throw new Error('No pudimos encontrar el post que buscas')
             // //de lo contrario, devolvemos el post obtenido
             // else res.json(searchedPost) 
-            const { postId } = req.params
-            const id = mongoose.Types.ObjectId(postId);
-            let p = await Post.aggregate([
-                {
-                $match : {"_id" : id}
+            //const id = mongoose.Types.ObjectId(postId);
+        //     let p = await Post.aggregate([
+        //         {
+        //         $match : {"_id" : id}
+        //     },
+        //     {
+        //         $lookup : {
+        //             from: "profiles",
+        //             localField : 'userId',
+        //             foreignField : '_id',
+        //             as : 'profile'
+        //         }
+        //     },
+        //     {
+        //                 $graphLookup: {
+        //                     from: "comments",
+        //                     startWith: "$commentId",
+        //                     connectFromField: "_id",
+        //                     connectToField: "_id",
+        //                     maxDepth: 2,
+        //                     depthField: "numConnections",
+        //                     as: "comentarios"
+        //                 }
+        //             },
+        //             {
+        //                 $unwind : '$comentarios'
+        //             },
+        //             {
+        //                 $graphLookup: {
+        //                     from: "profiles",
+        //                     startWith: "$comentarios.profileId",
+        //                     connectFromField: "_id",
+        //                     connectToField: "_id",
+        //                     maxDepth: 2,
+        //                     depthField: "numConnections",
+        //                     as: "usuarios"
+        //                 }
+        //             },
+        //             {
+        //                 $unwind : '$usuarios'
+        //             },
+        //         {$project : {userId:0, commentId : 0, profile : {content : 0}, usuarios : {content : 0}}}
+        // ]);
+        
+        
+        //join de la info de usuario con el userId contenido en el post
+        //el segundo parametro le indica que solamente me traiga el nombre, imagen e ID
+        let post = await Post.findById(postId).populate('userId', {
+            user_Name: 1,
+            image_profil: 1,
+            _id: 1
+        })
+
+        //join de la info de comentarios con el commentId contenido en el post
+        post = await post.populate( 'commentId')
+        
+        //aca estan los comentarios del post, solamente con el id del usuario que comento
+        let coments = post.commentId
+        //obtengo un array de promesas, que va a ir buscando la info de cada usuario con el profileId que hay en cada comentario
+        let comentUserPromises = coments.map( com => com.populate('profileId', {
+           user_Name: 1,
+           image_profil: 1,
+           _id: 1
+        }))
+        //obtenemos la info completa de los comentarios con el usuario que lo realizó
+        let comentsUsers = await Promise.all(comentUserPromises)
+
+        //objeto que va a enviar como respuesta
+        let postData = {
+            post:{
+                text: post.text,
+                multimedia: post.multimedia,
+                multimedia_id: post.multimedia_id,
+                category: post.category
             },
-            {
-                $lookup : {
-                    from: "profiles",
-                    localField : 'userId',
-                    foreignField : '_id',
-                    as : 'profile'
-                }
-            },
-            {
-                        $graphLookup: {
-                            from: "comments",
-                            startWith: "$commentId",
-                            connectFromField: "_id",
-                            connectToField: "_id",
-                            maxDepth: 2,
-                            depthField: "numConnections",
-                            as: "comentarios"
-                        }
-                    },
-                    {
-                        $unwind : '$comentarios'
-                    },
-                    {
-                        $graphLookup: {
-                            from: "profiles",
-                            startWith: "$comentarios.profileId",
-                            connectFromField: "_id",
-                            connectToField: "_id",
-                            maxDepth: 2,
-                            depthField: "numConnections",
-                            as: "usuarios"
-                        }
-                    },
-                    {
-                        $unwind : '$usuarios'
-                    },
-                {$project : {userId:0, commentId : 0, profile : {content : 0}, usuarios : {content : 0}}}
-        ]);
-        if(p.length){
-            const arr = {
-                userId : p[0].profile,
-                post : {
-                    _id : p[0]._id,
-                    text : p[0].text,
-                    multimedia : p[0].multimedia,
-                    multimedia_id : p[0].multimedia_id,
-                    category : p[0].category
-                },
-                comment : p.map((x) =>{
-                    return{
-                        comment : x.comentarios && x.comentarios,
-                        user : x.usuarios && x.usuarios
-                    }
-                })    
-            }
-            return res.status(200).json(arr)
+            userId: post.userId,
+            comments: comentsUsers
         }
+
+        res.status(200).json(postData)
+        // if(p.length){
+        //     let data = p[0]
+        //     const arr = {
+        //         userId : data.profile[0],
+        //         post : {
+        //             _id : data._id,
+        //             text : data.text,
+        //             multimedia : data.multimedia,
+        //             multimedia_id : data.multimedia_id,
+        //             category : data.category
+        //         },
+        //         comment : p.map((x) =>{
+        //             return{
+        //                 comment : x.comentarios && x.comentarios,
+        //                 user : x.usuarios && x.usuarios
+        //             }
+        //         })    
+        //     }
+        //     return res.status(200).json(arr)
+        // }
     
-        if(!p.length){
-            p = await Post.findById(postId).populate(['userId', 'commentId']);
-               res.status(200).json(p)
-         } 
+        // else if(!p.length){
+        //     p = await Post.findById(postId).populate(['userId', 'commentId']);
+        //        res.status(200).json(p)
+        //  } 
         }
         catch(error){
             res.status(400).send(error.message)


### PR DESCRIPTION
Ahora solo usa el método populate para vincular colecciones de mongo, el método aggregate hacía que a veces devuelva arrays en vez de objetos.